### PR TITLE
Validation message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_initializer (0.5.0)
+    smart_initializer (0.5.1)
       qonfig (~> 0.24)
       smart_engine (~> 0.11)
       smart_types (~> 0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,16 +94,17 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES
   armitage-rubocop (~> 1.7)
   bundler (~> 2.2)
-  pry (~> 0.13)
+  pry (~> 0.14)
   rake (~> 13.0)
   rspec (~> 3.10)
   simplecov (~> 0.21)
   smart_initializer!
 
 BUNDLED WITH
-   2.2.3
+   2.2.11

--- a/lib/smart_core/initializer/attribute.rb
+++ b/lib/smart_core/initializer/attribute.rb
@@ -97,10 +97,9 @@ class SmartCore::Initializer::Attribute
   # @since 0.5.1
   def validate!(value)
     type.validate!(value)
-  rescue => e
-    raise SmartCore::Initializer::IncorrectTypeError.new(
-      "Validation of attribute '#{name}' (#{type.identifier}) failed: #{e.message}"
-    )
+  rescue => error
+    raise SmartCore::Initializer::IncorrectTypeError,
+          "Validation of attribute '#{name}' (#{type.identifier}) failed: #{error.message}"
   end
 
   # @return [SmartCore::Initializer::Attribute]

--- a/lib/smart_core/initializer/attribute.rb
+++ b/lib/smart_core/initializer/attribute.rb
@@ -99,7 +99,8 @@ class SmartCore::Initializer::Attribute
     type.validate!(value)
   rescue => error
     raise SmartCore::Initializer::IncorrectTypeError,
-          "Validation of attribute '#{name}' (#{type.identifier}) failed: #{error.message}"
+          "Validation of attribute '#{name}' (#{type.identifier}, got #{value.class}) failed: " \
+          "#{error.message}"
   end
 
   # @return [SmartCore::Initializer::Attribute]

--- a/lib/smart_core/initializer/attribute.rb
+++ b/lib/smart_core/initializer/attribute.rb
@@ -90,6 +90,19 @@ class SmartCore::Initializer::Attribute
     )
   end
 
+  # @param value [Any]
+  # @return [void]
+  #
+  # @api private
+  # @since 0.5.1
+  def validate!(value)
+    type.validate!(value)
+  rescue => e
+    raise SmartCore::Initializer::IncorrectTypeError.new(
+      "Validation of attribute '#{name}' (#{type.identifier}) failed: #{e.message}"
+    )
+  end
+
   # @return [SmartCore::Initializer::Attribute]
   #
   # @api private

--- a/lib/smart_core/initializer/constructor.rb
+++ b/lib/smart_core/initializer/constructor.rb
@@ -113,6 +113,7 @@ class SmartCore::Initializer::Constructor
   #
   # @api private
   # @since 0.1.0
+  # @version 0.5.1
   def initialize_parameters(instance)
     parameter_definitions = klass.__params__.zip(parameters).to_h
 
@@ -133,6 +134,7 @@ class SmartCore::Initializer::Constructor
   #
   # @api private
   # @since 0.1.0
+  # @version 0.5.1
   def initialize_options(instance)
     klass.__options__.each do |attribute|
       option_value = options.fetch(attribute.name) { attribute.default }

--- a/lib/smart_core/initializer/constructor.rb
+++ b/lib/smart_core/initializer/constructor.rb
@@ -121,7 +121,7 @@ class SmartCore::Initializer::Constructor
         parameter_value = attribute.type.cast(parameter_value)
       end
 
-      attribute.type.validate!(parameter_value)
+      attribute.validate!(parameter_value)
 
       final_value = attribute.finalizer.call(parameter_value, instance)
       instance.instance_variable_set("@#{attribute.name}", final_value)
@@ -142,7 +142,7 @@ class SmartCore::Initializer::Constructor
         option_value = attribute.type.cast(option_value)
       end
 
-      attribute.type.validate!(option_value)
+      attribute.validate!(option_value)
 
       final_value = attribute.finalizer.call(option_value, instance)
       instance.instance_variable_set("@#{attribute.name}", final_value)

--- a/lib/smart_core/initializer/constructor.rb
+++ b/lib/smart_core/initializer/constructor.rb
@@ -114,7 +114,7 @@ class SmartCore::Initializer::Constructor
   # @api private
   # @since 0.1.0
   def initialize_parameters(instance)
-    parameter_definitions = Hash[klass.__params__.zip(parameters)]
+    parameter_definitions = klass.__params__.zip(parameters).to_h
 
     parameter_definitions.each_pair do |attribute, parameter_value|
       if !attribute.type.valid?(parameter_value) && attribute.cast?
@@ -133,7 +133,6 @@ class SmartCore::Initializer::Constructor
   #
   # @api private
   # @since 0.1.0
-  # rubocop:disable Metrics/AbcSize
   def initialize_options(instance)
     klass.__options__.each do |attribute|
       option_value = options.fetch(attribute.name) { attribute.default }
@@ -148,7 +147,6 @@ class SmartCore::Initializer::Constructor
       instance.instance_variable_set("@#{attribute.name}", final_value)
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   # @param instance [Any]
   # @return [void]

--- a/lib/smart_core/initializer/errors.rb
+++ b/lib/smart_core/initializer/errors.rb
@@ -74,6 +74,10 @@ module SmartCore::Initializer
   UnsupportedTypeOperationError = Class.new(TypeSystemError)
 
   # @api public
+  # @since 0.5.1
+  IncorrectTypeError = Class.new(TypeSystemError)
+
+  # @api public
   # @since 0.1.0
   TypeCastingUnsupportedError = Class.new(UnsupportedTypeOperationError)
 end

--- a/lib/smart_core/initializer/plugins/thy_types/thy_types/abstract_factory.rb
+++ b/lib/smart_core/initializer/plugins/thy_types/thy_types/abstract_factory.rb
@@ -80,6 +80,7 @@ module SmartCore::Initializer::TypeSystem
       #
       # @api private
       # @since 0.1.0
+      # @version 0.5.1
       def build_interop(identifier, valid_op, validate_op, cast_op)
         ThyTypes.new(identifier, valid_op, validate_op, cast_op)
       end

--- a/lib/smart_core/initializer/plugins/thy_types/thy_types/abstract_factory.rb
+++ b/lib/smart_core/initializer/plugins/thy_types/thy_types/abstract_factory.rb
@@ -28,6 +28,15 @@ module SmartCore::Initializer::TypeSystem
         end
       end
 
+      # @param type [Any]
+      # @return [String]
+      #
+      # @api private
+      # @since 0.5.1
+      def build_identifier(type)
+        type.name
+      end
+
       # @param type [Thy::Type, #check]
       # @return [SmartCore::Initializer::TypeSystem::ThyTypes::Operation::Valid]
       #
@@ -63,6 +72,7 @@ module SmartCore::Initializer::TypeSystem
         ThyTypes::Operation::Cast.new(type)
       end
 
+      # @param identifier [String]
       # @param valid_op [SmartCore::Initializer::TypeSystem::ThyTypes::Operation::Valid]
       # @param valid_op [SmartCore::Initializer::TypeSystem::ThyTypes::Operation::Validate]
       # @param valid_op [SmartCore::Initializer::TypeSystem::ThyTypes::Operation::Cast]
@@ -70,8 +80,8 @@ module SmartCore::Initializer::TypeSystem
       #
       # @api private
       # @since 0.1.0
-      def build_interop(valid_op, validate_op, cast_op)
-        ThyTypes.new(valid_op, validate_op, cast_op)
+      def build_interop(identifier, valid_op, validate_op, cast_op)
+        ThyTypes.new(identifier, valid_op, validate_op, cast_op)
       end
     end
   end

--- a/lib/smart_core/initializer/type_system/interop.rb
+++ b/lib/smart_core/initializer/type_system/interop.rb
@@ -55,6 +55,7 @@ class SmartCore::Initializer::TypeSystem::Interop
   #
   # @api private
   # @since 0.1.0
+  # @version 0.5.1
   def initialize(identifier, valid_op, validate_op, cast_op)
     @identifier = identifier
     @valid_op = valid_op

--- a/lib/smart_core/initializer/type_system/interop.rb
+++ b/lib/smart_core/initializer/type_system/interop.rb
@@ -41,6 +41,13 @@ class SmartCore::Initializer::TypeSystem::Interop
     end
   end
 
+  # @return [String]
+  #
+  # @api private
+  # @since 0.5.1
+  attr_reader :identifier
+
+  # @param identifier [String]
   # @param valid_op [SmartCore::Initializer::TypeSystem::Interop::Operation]
   # @param validate_op [SmartCore::Initializer::TypeSystem::Interop::Operation]
   # @param cast_op [SmartCore::Initializer::TypeSystem::Interop::Operation]
@@ -48,7 +55,8 @@ class SmartCore::Initializer::TypeSystem::Interop
   #
   # @api private
   # @since 0.1.0
-  def initialize(valid_op, validate_op, cast_op)
+  def initialize(identifier, valid_op, validate_op, cast_op)
+    @identifier = identifier
     @valid_op = valid_op
     @validate_op = validate_op
     @cast_op = cast_op

--- a/lib/smart_core/initializer/type_system/interop/abstract_factory.rb
+++ b/lib/smart_core/initializer/type_system/interop/abstract_factory.rb
@@ -74,6 +74,7 @@ class SmartCore::Initializer::TypeSystem::Interop::AbstractFactory
     #
     # @api private
     # @since 0.1.0
+    # @version 0.5.1
     def build_interop(identifier, valid_op, validate_op, cast_op); end
   end
 end

--- a/lib/smart_core/initializer/type_system/interop/abstract_factory.rb
+++ b/lib/smart_core/initializer/type_system/interop/abstract_factory.rb
@@ -13,11 +13,12 @@ class SmartCore::Initializer::TypeSystem::Interop::AbstractFactory
     def create(type)
       prevent_incompatible_type!(type)
 
+      identifier = build_identifier(type)
       valid_op = build_valid_operation(type)
       validate_op = build_validate_operation(type)
       cast_op = build_cast_operation(type)
 
-      build_interop(valid_op, validate_op, cast_op)
+      build_interop(identifier, valid_op, validate_op, cast_op)
     end
 
     # @return [Any]
@@ -25,6 +26,13 @@ class SmartCore::Initializer::TypeSystem::Interop::AbstractFactory
     # @api private
     # @since 0.1.0
     def generic_type_object; end
+
+    # @param type [Any]
+    # @return [String]
+    #
+    # @api private
+    # @since 0.5.1
+    def build_identifier(type); end
 
     # @param type [Any]
     # @return [void]
@@ -58,6 +66,7 @@ class SmartCore::Initializer::TypeSystem::Interop::AbstractFactory
     # @since 0.1.0
     def build_cast_operation(type); end
 
+    # @param identifier [String]
     # @param valid_op [SmartCore::Initializer::TypeSystem::Interop::Operation]
     # @param validate_op [SmartCore::Initializer::TypeSystem::Interop::Operation]
     # @param cast_op [SmartCore::Initializer::TypeSystem::Interop::Operation]
@@ -65,6 +74,6 @@ class SmartCore::Initializer::TypeSystem::Interop::AbstractFactory
     #
     # @api private
     # @since 0.1.0
-    def build_interop(valid_op, validate_op, cast_op); end
+    def build_interop(identifier, valid_op, validate_op, cast_op); end
   end
 end

--- a/lib/smart_core/initializer/type_system/smart_types/abstract_factory.rb
+++ b/lib/smart_core/initializer/type_system/smart_types/abstract_factory.rb
@@ -74,6 +74,7 @@ module SmartCore::Initializer::TypeSystem
       #
       # @api private
       # @since 0.1.0
+      # @version 0.5.1
       def build_interop(identifier, valid_op, validate_op, cast_op)
         SmartTypes.new(identifier, valid_op, validate_op, cast_op)
       end

--- a/lib/smart_core/initializer/type_system/smart_types/abstract_factory.rb
+++ b/lib/smart_core/initializer/type_system/smart_types/abstract_factory.rb
@@ -22,6 +22,15 @@ module SmartCore::Initializer::TypeSystem
         end
       end
 
+      # @param type [Any]
+      # @return [String]
+      #
+      # @api private
+      # @since 0.5.1
+      def build_identifier(type)
+        type.name
+      end
+
       # @param type [SmartCore::Types::Primitive]
       # @return [SmartCore::Initializer::TypeSystem::SmartTypes::Operation::Valid]
       #
@@ -57,6 +66,7 @@ module SmartCore::Initializer::TypeSystem
         SmartTypes::Operation::Cast.new(type)
       end
 
+      # @param identifier [String]
       # @param valid_op [SmartCore::Initializer::TypeSystem::SmartTypes::Operation::Valid]
       # @param valid_op [SmartCore::Initializer::TypeSystem::SmartTypes::Operation::Validate]
       # @param valid_op [SmartCore::Initializer::TypeSystem::SmartTypes::Operation::Cast]
@@ -64,8 +74,8 @@ module SmartCore::Initializer::TypeSystem
       #
       # @api private
       # @since 0.1.0
-      def build_interop(valid_op, validate_op, cast_op)
-        SmartTypes.new(valid_op, validate_op, cast_op)
+      def build_interop(identifier, valid_op, validate_op, cast_op)
+        SmartTypes.new(identifier, valid_op, validate_op, cast_op)
       end
     end
   end

--- a/lib/smart_core/initializer/version.rb
+++ b/lib/smart_core/initializer/version.rb
@@ -6,7 +6,7 @@ module SmartCore
     #
     # @api public
     # @since 0.1.0
-    # @version 0.5.0
-    VERSION = '0.5.0'
+    # @version 0.5.1
+    VERSION = '0.5.1'
   end
 end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe 'Smoke Test' do
       param :user_id, SmartCore::Types::Value::Integer
     end
 
-    expect { klass.new("1") }.to raise_error(
+    expect { klass.new('1') }.to raise_error(
       SmartCore::Initializer::IncorrectTypeError,
       "Validation of attribute 'user_id' (Integer) failed: Invalid type"
     )

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe 'Smoke Test' do
 
     expect { klass.new('1') }.to raise_error(
       SmartCore::Initializer::IncorrectTypeError,
-      "Validation of attribute 'user_id' (Integer) failed: Invalid type"
+      "Validation of attribute 'user_id' (Integer, got String) failed: Invalid type"
     )
   end
 end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -102,8 +102,10 @@ RSpec.describe 'Smoke Test' do
       option :age, :integer
     end
 
-    expect { Animal.new(123, age: 123) }.to raise_error(SmartCore::Types::TypeError)
-    expect { Animal.new('test', age: 'test') }.to raise_error(SmartCore::Types::TypeError)
+    expect { Animal.new(123, age: 123) }
+      .to raise_error(SmartCore::Initializer::IncorrectTypeError)
+    expect { Animal.new('test', age: 'test') }
+      .to raise_error(SmartCore::Initializer::IncorrectTypeError)
     expect { Animal.new('test', age: 123) }.not_to raise_error
   end
 
@@ -158,5 +160,18 @@ RSpec.describe 'Smoke Test' do
 
     expect(instance).to respond_to(:kek)
     expect(instance.kek).to eq('pek')
+  end
+
+  specify 'validation exception' do
+    klass = Class.new do
+      include SmartCore::Initializer
+
+      param :user_id, SmartCore::Types::Value::Integer
+    end
+
+    expect { klass.new("1") }.to raise_error(
+      SmartCore::Initializer::IncorrectTypeError,
+      "Validation of attribute 'user_id' (Integer) failed: Invalid type"
+    )
   end
 end


### PR DESCRIPTION
Improving validation message, e.g.:

```Validation of attribute 'user_id' (Integer, got String) failed: Invalid type```

instead of 

```Invalid type```

Plus some style fixing according to rubocop.