### PR TITLE
New `strict_options` config flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.1] - 2021-06-23
 ## Added
-- `strict_options_count` config option;
+- `strict_options_count` config option for non-strict checking of passed options;
 
 ## [0.6.0] - 2021-06-23
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.1] - 2021-06-23
 ## Added
-- `strict_options_count` config option for non-strict checking of passed options;
+- `strict_kwargs` config option for non-strict checking of passed options;
 
 ## [0.6.0] - 2021-06-23
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.1] - 2021-06-23
 ## Added
-- `strict_kwargs` config option for non-strict checking of passed options;
+- `strict_options` config option for non-strict checking of passed options;
 
 ## [0.6.0] - 2021-06-23
 ## Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_initializer (0.5.1)
+    smart_initializer (0.5.2)
       qonfig (~> 0.24)
       smart_engine (~> 0.11)
       smart_types (~> 0.4)
@@ -107,4 +107,4 @@ DEPENDENCIES
   smart_initializer!
 
 BUNDLED WITH
-   2.2.11
+   2.2.19

--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ user.__attributes__ # => { first_name: 'Rustam', second_name: 'Ibragimov', age: 
 - you can read config values via `[]` or `.config.settings` or `.config[key]`;
 - setitngs:
   - `default_type_system` - default type system (`smart_types` by default);
-  - `strict_kwargs` - raise an error when got unknown options if true (`true` by default);
+  - `strict_options` - raise an error when got unknown options if true (`true` by default);
 
 ```ruby
 # configure:
 SmartCore::Initializer::Configuration.configure do |config|
   config.default_type_system = :smart_types # default setting value
-  config.strict_kwargs = true # default setting value
+  config.strict_options = true # default setting value
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,13 @@ user.__attributes__ # => { first_name: 'Rustam', second_name: 'Ibragimov', age: 
 - you can read config values via `[]` or `.config.settings` or `.config[key]`;
 - setitngs:
   - `default_type_system` - default type system (`smart_types` by default);
+  - `strict_options_count` - raise an error when got unknown options (`true` by default);
 
 ```ruby
 # configure:
 SmartCore::Initializer::Configuration.configure do |config|
   config.default_type_system = :smart_types # default setting value
+  config.strict_options_count = true # default setting value
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ user.__attributes__ # => { first_name: 'Rustam', second_name: 'Ibragimov', age: 
 - you can read config values via `[]` or `.config.settings` or `.config[key]`;
 - setitngs:
   - `default_type_system` - default type system (`smart_types` by default);
-  - `strict_options_count` - raise an error when got unknown options (`true` by default);
+  - `strict_options_count` - raise an error when got unknown options if true (`true` by default);
 
 ```ruby
 # configure:

--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ user.__attributes__ # => { first_name: 'Rustam', second_name: 'Ibragimov', age: 
 - you can read config values via `[]` or `.config.settings` or `.config[key]`;
 - setitngs:
   - `default_type_system` - default type system (`smart_types` by default);
-  - `strict_options_count` - raise an error when got unknown options if true (`true` by default);
+  - `strict_kwargs` - raise an error when got unknown options if true (`true` by default);
 
 ```ruby
 # configure:
 SmartCore::Initializer::Configuration.configure do |config|
   config.default_type_system = :smart_types # default setting value
-  config.strict_options_count = true # default setting value
+  config.strict_kwargs = true # default setting value
 end
 ```
 

--- a/lib/smart_core/initializer/configuration.rb
+++ b/lib/smart_core/initializer/configuration.rb
@@ -31,8 +31,8 @@ module SmartCore::Initializer::Configuration
       SmartCore::Initializer::TypeSystem.resolve(value) rescue false
     end
 
-    setting :strict_options_count, true
-    validate :strict_options_count do |value|
+    setting :strict_kwargs, true
+    validate :strict_kwargs do |value|
       !!value == value # check if it's a boolean value
     end
   end

--- a/lib/smart_core/initializer/configuration.rb
+++ b/lib/smart_core/initializer/configuration.rb
@@ -31,8 +31,8 @@ module SmartCore::Initializer::Configuration
       SmartCore::Initializer::TypeSystem.resolve(value) rescue false
     end
 
-    setting :strict_kwargs, true
-    validate :strict_kwargs do |value|
+    setting :strict_options, true
+    validate :strict_options do |value|
       !!value == value # check if it's a boolean value
     end
   end

--- a/lib/smart_core/initializer/configuration.rb
+++ b/lib/smart_core/initializer/configuration.rb
@@ -24,10 +24,16 @@ module SmartCore::Initializer::Configuration
   end
 
   # @since 0.1.0
+  # @version 0.5.2
   configuration do
     setting :default_type_system, :smart_types
     validate :default_type_system do |value|
       SmartCore::Initializer::TypeSystem.resolve(value) rescue false
+    end
+
+    setting :strict_options_count, true
+    validate :strict_options_count do |value|
+      !!value == value # check if it's a boolean value
     end
   end
 end

--- a/lib/smart_core/initializer/constructor.rb
+++ b/lib/smart_core/initializer/constructor.rb
@@ -97,7 +97,7 @@ class SmartCore::Initializer::Constructor
     raise(
       SmartCore::Initializer::OptionArgumentError,
       "Unknown options: #{unknown_options.join(', ')}"
-    ) if unknown_options.any? && SmartCore::Initializer::Configuration[:strict_kwargs]
+    ) if unknown_options.any? && SmartCore::Initializer::Configuration[:strict_options]
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/lib/smart_core/initializer/constructor.rb
+++ b/lib/smart_core/initializer/constructor.rb
@@ -72,6 +72,7 @@ class SmartCore::Initializer::Constructor
   #
   # @api private
   # @since 0.1.0
+  # @version 0.5.2
   # rubocop:disable Metrics/AbcSize
   def prevent_attribute_insufficiency
     required_parameter_count = klass.__params__.size
@@ -96,7 +97,7 @@ class SmartCore::Initializer::Constructor
     raise(
       SmartCore::Initializer::OptionArgumentError,
       "Unknown options: #{unknown_options.join(', ')}"
-    ) if unknown_options.any?
+    ) if unknown_options.any? && SmartCore::Initializer::Configuration[:strict_options_count]
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/lib/smart_core/initializer/constructor.rb
+++ b/lib/smart_core/initializer/constructor.rb
@@ -97,7 +97,7 @@ class SmartCore::Initializer::Constructor
     raise(
       SmartCore::Initializer::OptionArgumentError,
       "Unknown options: #{unknown_options.join(', ')}"
-    ) if unknown_options.any? && SmartCore::Initializer::Configuration[:strict_options_count]
+    ) if unknown_options.any? && SmartCore::Initializer::Configuration[:strict_kwargs]
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/lib/smart_core/initializer/version.rb
+++ b/lib/smart_core/initializer/version.rb
@@ -6,7 +6,7 @@ module SmartCore
     #
     # @api public
     # @since 0.1.0
-    # @version 0.5.1
-    VERSION = '0.5.1'
+    # @version 0.5.2
+    VERSION = '0.5.2'
   end
 end

--- a/spec/features/configuration_spec.rb
+++ b/spec/features/configuration_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe 'Initializer configuration' do
     end
   end
 
-  describe 'strict_kwargs' do
+  describe 'strict_options' do
     specify 'default value' do
-      expect(SmartCore::Initializer::Configuration[:strict_kwargs]).to be_truthy
+      expect(SmartCore::Initializer::Configuration[:strict_options]).to be_truthy
     end
 
     specify 'unsupported value - fails' do
       expect(SmartCore::Initializer::Configuration.config.valid_with?({
-        strict_kwargs: :kek_pek
+        strict_options: :kek_pek
       })).to eq(false)
     end
   end

--- a/spec/features/configuration_spec.rb
+++ b/spec/features/configuration_spec.rb
@@ -18,4 +18,16 @@ RSpec.describe 'Initializer configuration' do
       })).to eq(true)
     end
   end
+
+  describe 'strict_options_count' do
+    specify 'default value' do
+      expect(SmartCore::Initializer::Configuration[:strict_options_count]).to be_truthy
+    end
+
+    specify 'unsupported value - fails' do
+      expect(SmartCore::Initializer::Configuration.config.valid_with?({
+        strict_options_count: :kek_pek
+      })).to eq(false)
+    end
+  end
 end

--- a/spec/features/configuration_spec.rb
+++ b/spec/features/configuration_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe 'Initializer configuration' do
     end
   end
 
-  describe 'strict_options_count' do
+  describe 'strict_kwargs' do
     specify 'default value' do
-      expect(SmartCore::Initializer::Configuration[:strict_options_count]).to be_truthy
+      expect(SmartCore::Initializer::Configuration[:strict_kwargs]).to be_truthy
     end
 
     specify 'unsupported value - fails' do
       expect(SmartCore::Initializer::Configuration.config.valid_with?({
-        strict_options_count: :kek_pek
+        strict_kwargs: :kek_pek
       })).to eq(false)
     end
   end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -138,17 +138,17 @@ RSpec.describe 'Smoke Test' do
       end
     end
 
-    describe 'strict_options_count option' do
+    describe 'strict_kwargs option' do
       before do
-        SmartCore::Initializer::Configuration.config[:strict_options_count] = strict_options_count
+        SmartCore::Initializer::Configuration.config[:strict_kwargs] = strict_kwargs
       end
 
       after do
-        SmartCore::Initializer::Configuration.config[:strict_options_count] = true
+        SmartCore::Initializer::Configuration.config[:strict_kwargs] = true
       end
 
       context "when it's true" do
-        let(:strict_options_count) { true }
+        let(:strict_kwargs) { true }
 
         specify 'fails on unknown options' do
           expect do
@@ -166,7 +166,7 @@ RSpec.describe 'Smoke Test' do
       end
 
       context "when it's false" do
-        let(:strict_options_count) { false }
+        let(:strict_kwargs) { false }
 
         specify 'skips unknown options' do
           expect { klass.new(user_id: 7, lol_kek: 123) }.not_to raise_error

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -138,17 +138,17 @@ RSpec.describe 'Smoke Test' do
       end
     end
 
-    describe 'strict_kwargs option' do
+    describe 'strict_options option' do
       before do
-        SmartCore::Initializer::Configuration.config[:strict_kwargs] = strict_kwargs
+        SmartCore::Initializer::Configuration.config[:strict_options] = strict_options
       end
 
       after do
-        SmartCore::Initializer::Configuration.config[:strict_kwargs] = true
+        SmartCore::Initializer::Configuration.config[:strict_options] = true
       end
 
       context "when it's true" do
-        let(:strict_kwargs) { true }
+        let(:strict_options) { true }
 
         specify 'fails on unknown options' do
           expect do
@@ -166,7 +166,7 @@ RSpec.describe 'Smoke Test' do
       end
 
       context "when it's false" do
-        let(:strict_kwargs) { false }
+        let(:strict_options) { false }
 
         specify 'skips unknown options' do
           expect { klass.new(user_id: 7, lol_kek: 123) }.not_to raise_error

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -129,24 +129,50 @@ RSpec.describe 'Smoke Test' do
     end.to raise_error(SmartCore::Initializer::OptionOverlapError)
   end
 
-  it 'instantiation: fails on unknown options' do
-    klass = Class.new do
-      include SmartCore::Initializer
-      option :user_id
-      option :role_id, default: 123
+  context 'instantiation' do
+    let(:klass) do
+      Class.new do
+        include SmartCore::Initializer
+        option :user_id
+        option :role_id, default: 123
+      end
     end
 
-    expect do
-      klass.new(user_id: 7, lol_kek: 123)
-    end.to raise_error(SmartCore::Initializer::OptionArgumentError)
+    describe 'strict_options_count option' do
+      before do
+        SmartCore::Initializer::Configuration.config[:strict_options_count] = strict_options_count
+      end
 
-    expect do
-      klass.new(user_id: 7, role_id: 55, lol_kek: 123)
-    end.to raise_error(SmartCore::Initializer::OptionArgumentError)
+      after do
+        SmartCore::Initializer::Configuration.config[:strict_options_count] = true
+      end
 
-    expect { klass.new(user_id: 7) }.not_to raise_error
+      context "when it's true" do
+        let(:strict_options_count) { true }
 
-    expect { klass.new(user_id: 7, role_id: 7) }.not_to raise_error
+        specify 'fails on unknown options' do
+          expect do
+            klass.new(user_id: 7, lol_kek: 123)
+          end.to raise_error(SmartCore::Initializer::OptionArgumentError)
+
+          expect do
+            klass.new(user_id: 7, role_id: 55, lol_kek: 123)
+          end.to raise_error(SmartCore::Initializer::OptionArgumentError)
+
+          expect { klass.new(user_id: 7) }.not_to raise_error
+
+          expect { klass.new(user_id: 7, role_id: 7) }.not_to raise_error
+        end
+      end
+
+      context "when it's false" do
+        let(:strict_options_count) { false }
+
+        specify 'skips unknown options' do
+          expect { klass.new(user_id: 7, lol_kek: 123) }.not_to raise_error
+        end
+      end
+    end
   end
 
   specify 'initializer behavior extension' do


### PR DESCRIPTION
Added a flag for skipping unknown options instead of raising an error.