### PR TITLE
Fix validation for finalize lamda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `finalize` now accepts lambdas with arity -2. For example `->(a, *b) {}` or `:freeze.to_proc` in
-  `Ruby >= 3` returns lambda with arity equal to `-2`.
+- `finalize` now accepts lambdas with arity `-2`. For example `->(a, *b) {}` or `:freeze.to_proc`
+  which in `Ruby >= 3` returns lambda with arity equal to `-2`.
 
 ## [0.9.0] - 2021-12-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Fixed
+
+- `finalize` now accepts lambdas with arity -2. For example `->(a, *b) {}` or `:freeze.to_proc` in
+  `Ruby >= 3` returns lambda with arity equal to `-2`.
+
 ## [0.9.0] - 2021-12-19
 ### Changed
 - `:finalize` block is not invoked on the `option` with `optional: true` flag;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## [0.9.1] - 2022-03-06
 
 ### Fixed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_initializer (0.9.0)
+    smart_initializer (0.9.1)
       qonfig (~> 0.24)
       smart_engine (~> 0.11)
       smart_types (~> 0.4)
@@ -36,7 +36,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    qonfig (0.26.0)
+    qonfig (0.27.0)
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   armitage-rubocop (~> 1.23)

--- a/gemfiles/with_external_deps.gemfile.lock
+++ b/gemfiles/with_external_deps.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    smart_initializer (0.8.0)
+    smart_initializer (0.9.1)
       qonfig (~> 0.24)
       smart_engine (~> 0.11)
       smart_types (~> 0.4)
@@ -36,7 +36,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    qonfig (0.26.0)
+    qonfig (0.27.0)
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.3)
@@ -84,7 +84,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    smart_engine (0.11.0)
+    smart_engine (0.12.0)
     smart_types (0.7.0)
       smart_engine (~> 0.11)
     thy (0.1.4)
@@ -96,6 +96,7 @@ GEM
 PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   armitage-rubocop (~> 1.23)
@@ -108,4 +109,4 @@ DEPENDENCIES
   thy (~> 0.1.4)
 
 BUNDLED WITH
-   2.2.31
+   2.2.32

--- a/gemfiles/without_external_deps.gemfile.lock
+++ b/gemfiles/without_external_deps.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    smart_initializer (0.8.0)
+    smart_initializer (0.9.0)
       qonfig (~> 0.24)
       smart_engine (~> 0.11)
       smart_types (~> 0.4)
@@ -35,7 +35,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    qonfig (0.26.0)
+    qonfig (0.27.0)
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.3)
@@ -93,6 +93,7 @@ GEM
 PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   armitage-rubocop (~> 1.23)

--- a/gemfiles/without_external_deps.gemfile.lock
+++ b/gemfiles/without_external_deps.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    smart_initializer (0.9.0)
+    smart_initializer (0.9.1)
       qonfig (~> 0.24)
       smart_engine (~> 0.11)
       smart_types (~> 0.4)

--- a/lib/smart_core/initializer/attribute/factory/base.rb
+++ b/lib/smart_core/initializer/attribute/factory/base.rb
@@ -90,7 +90,7 @@ class SmartCore::Initializer::Attribute::Factory::Base
 
       # rubocop:disable Style/SoleNestedConditional
       if finalize.is_a?(::Proc) && finalize.lambda?
-        unless [1, -1, -2].include?(finalize.arity)
+        unless allowed_lambda_arity.bsearch { |element| finalize.arity <=> element }
           raise(
             SmartCore::Initializer::ArgumentError,
             'Lambda-based finalizer should have arity equal to 1, -1 or -2 ' \
@@ -101,6 +101,13 @@ class SmartCore::Initializer::Attribute::Factory::Base
       # rubocop:enable Style/SoleNestedConditional
 
       SmartCore::Initializer::Attribute::Finalizer.create(finalize)
+    end
+
+    # return [Array<Integer>]
+    # @api private
+    # @since 0.9.1
+    def allowed_lambda_arity
+      @allowed_lambda_arity ||= [-2, -1, 1].freeze
     end
 
     # @param mutable [Boolean]

--- a/lib/smart_core/initializer/attribute/factory/base.rb
+++ b/lib/smart_core/initializer/attribute/factory/base.rb
@@ -90,10 +90,10 @@ class SmartCore::Initializer::Attribute::Factory::Base
 
       # rubocop:disable Style/SoleNestedConditional
       if finalize.is_a?(::Proc) && finalize.lambda?
-        unless (finalize.arity == 1 || finalize.arity == -1)
+        unless [1, -1, -2].include?(finalize.arity)
           raise(
             SmartCore::Initializer::ArgumentError,
-            'Lambda-based finalizer should have arity equal to 1 or equal to -1 ' \
+            'Lambda-based finalizer should have arity equal to 1, -1 or -2 ' \
             '(your lambda object should require one attribute)'
           ) # TODO: show the name of attribute in error message (if the name is a valid, of course)
         end

--- a/lib/smart_core/initializer/attribute/factory/base.rb
+++ b/lib/smart_core/initializer/attribute/factory/base.rb
@@ -93,8 +93,9 @@ class SmartCore::Initializer::Attribute::Factory::Base
         unless allowed_lambda_arity.bsearch { |element| finalize.arity <=> element }
           raise(
             SmartCore::Initializer::ArgumentError,
-            'Lambda-based finalizer should have arity equal to 1, -1 or -2 ' \
-            '(your lambda object should require one attribute)'
+            "Lambda-based finalizer should have arity " \
+            "equal to #{allowed_lambda_arity.join(', ')} " \
+            "(your lambda object should require one attribute)"
           ) # TODO: show the name of attribute in error message (if the name is a valid, of course)
         end
       end

--- a/lib/smart_core/initializer/version.rb
+++ b/lib/smart_core/initializer/version.rb
@@ -6,7 +6,7 @@ module SmartCore
     #
     # @api public
     # @since 0.1.0
-    # @version 0.9.0
-    VERSION = '0.9.0'
+    # @version 0.9.1
+    VERSION = '0.9.1'
   end
 end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -348,6 +348,13 @@ RSpec.describe 'Smoke Test' do
         end
       end.not_to raise_error
 
+      expect do
+        Class.new do
+          include SmartCore::Initializer
+          param :a, finalize: -> (req_arg, *val) {}
+        end
+      end.not_to raise_error
+
       # NOTE: proc objects can omit attribute in their signature
       expect do
         Class.new do


### PR DESCRIPTION
# Changes

## Fixes

- `finalize` now accepts lambdas with arity `-2`. For example `->(a, *b) {}` or `:freeze.to_proc` which in
  `Ruby >= 3` returns lambda with arity equal to `-2`.