### PR TITLE
Improve type error messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_initializer (0.11.1)
+    smart_initializer (0.12.0)
       qonfig (~> 0.24)
       smart_engine (~> 0.16)
       smart_types (~> 0.8)
@@ -21,6 +21,7 @@ GEM
       rubocop-rake (= 0.6.0)
       rubocop-rspec (= 2.13.2)
     ast (2.4.2)
+    bigdecimal (3.1.8)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
@@ -30,6 +31,7 @@ GEM
     json (2.6.2)
     method_source (1.0.0)
     minitest (5.16.3)
+    ostruct (0.6.0)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -94,10 +96,13 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
 
 DEPENDENCIES
   armitage-rubocop (~> 1.30)
+  bigdecimal
   bundler (~> 2.3)
+  ostruct
   pry (~> 0.14)
   rake (~> 13.0)
   rspec (~> 3.11)
@@ -105,4 +110,4 @@ DEPENDENCIES
   smart_initializer!
 
 BUNDLED WITH
-   2.3.17
+   2.5.19

--- a/lib/smart_core/initializer/attribute/factory/base.rb
+++ b/lib/smart_core/initializer/attribute/factory/base.rb
@@ -132,7 +132,7 @@ class SmartCore::Initializer::Attribute::Factory::Base
     #
     # @api private
     # @since 0.4.0
-    def preapre_as_param(as)
+    def prepare_as_param(as)
       unless as.is_a?(::NilClass) || as.is_a?(::String) || as.is_a?(::Symbol)
         raise(SmartCore::Initializer::ArgumentError, <<~ERROR_MESSAGE)
           Attribute alias should be a type of String or Symbol

--- a/lib/smart_core/initializer/attribute/factory/option.rb
+++ b/lib/smart_core/initializer/attribute/factory/option.rb
@@ -5,6 +5,7 @@ module SmartCore::Initializer::Attribute::Factory
   # @since 0.8.0
   class Option < Base
     class << self
+      # @param klass [Class]
       # @param name [String, Symbol]
       # @param type [String, Symbol, Any]
       # @param type_system [String, Symbol]
@@ -19,7 +20,7 @@ module SmartCore::Initializer::Attribute::Factory
       #
       # @api private
       # @since 0.8.0
-      def create(name, type, type_system, privacy, finalize, cast, mutable, as, default, optional)
+      def create(klass, name, type, type_system, privacy, finalize, cast, mutable, as, default, optional)
         prepared_name        = prepare_name_param(name)
         prepared_privacy     = prepare_privacy_param(privacy)
         prepared_finalize    = prepare_finalize_param(finalize)
@@ -27,11 +28,12 @@ module SmartCore::Initializer::Attribute::Factory
         prepared_type_system = prepare_type_system_param(type_system)
         prepared_type        = prepare_type_param(type, prepared_type_system)
         prepared_mutable     = prepare_mutable_param(mutable)
-        prepared_as          = preapre_as_param(as)
+        prepared_as          = prepare_as_param(as)
         prepared_default     = prepare_default_param(default)
         prepared_optional    = prepare_optional_param(optional)
 
         create_attribute(
+          klass,
           prepared_name,
           prepared_type,
           prepared_type_system,
@@ -47,6 +49,7 @@ module SmartCore::Initializer::Attribute::Factory
 
       private
 
+      # @param klass [Class]
       # @param name [String]
       # @param type [SmartCore::Initializer::TypeSystem::Interop]
       # @param type_system [Class<SmartCore::Initializer::TypeSystem::Interop>]
@@ -62,6 +65,7 @@ module SmartCore::Initializer::Attribute::Factory
       # @api private
       # @since 0.8.0
       def create_attribute(
+        klass,
         name,
         type,
         type_system,
@@ -74,7 +78,7 @@ module SmartCore::Initializer::Attribute::Factory
         optional
       )
         SmartCore::Initializer::Attribute::Value::Option.new(
-          name, type, type_system, privacy, finalize, cast, mutable, as, default, optional
+          klass, name, type, type_system, privacy, finalize, cast, mutable, as, default, optional
         )
       end
 

--- a/lib/smart_core/initializer/attribute/factory/param.rb
+++ b/lib/smart_core/initializer/attribute/factory/param.rb
@@ -5,6 +5,7 @@ module SmartCore::Initializer::Attribute::Factory
   # @since 0.8.0
   class Param < Base
     class << self
+      # @param klass [Class]
       # @param name [String, Symbol]
       # @param type [String, Symbol, Any]
       # @param type_system [String, Symbol]
@@ -17,7 +18,7 @@ module SmartCore::Initializer::Attribute::Factory
       #
       # @api private
       # @since 0.8.0
-      def create(name, type, type_system, privacy, finalize, cast, mutable, as)
+      def create(klass, name, type, type_system, privacy, finalize, cast, mutable, as)
         prepared_name        = prepare_name_param(name)
         prepared_privacy     = prepare_privacy_param(privacy)
         prepared_finalize    = prepare_finalize_param(finalize)
@@ -25,9 +26,10 @@ module SmartCore::Initializer::Attribute::Factory
         prepared_type_system = prepare_type_system_param(type_system)
         prepared_type        = prepare_type_param(type, prepared_type_system)
         prepared_mutable     = prepare_mutable_param(mutable)
-        prepared_as          = preapre_as_param(as)
+        prepared_as          = prepare_as_param(as)
 
         create_attribute(
+          klass,
           prepared_name,
           prepared_type,
           prepared_type_system,
@@ -53,9 +55,9 @@ module SmartCore::Initializer::Attribute::Factory
       #
       # @api private
       # @since 0.8.0
-      def create_attribute(name, type, type_system, privacy, finalize, cast, mutable, as)
+      def create_attribute(klass, name, type, type_system, privacy, finalize, cast, mutable, as)
         SmartCore::Initializer::Attribute::Value::Param.new(
-          name, type, type_system, privacy, finalize, cast, mutable, as
+          klass, name, type, type_system, privacy, finalize, cast, mutable, as
         )
       end
     end

--- a/lib/smart_core/initializer/attribute/value/base.rb
+++ b/lib/smart_core/initializer/attribute/value/base.rb
@@ -38,6 +38,12 @@ class SmartCore::Initializer::Attribute::Value::Base
   # @since 0.8.0
   DEFAULT_MUTABLE = false
 
+  # @return [Class]
+  #
+  # @api private
+  # @since 0.12.0
+  attr_reader :klass
+
   # @return [Symbol]
   #
   # @api private
@@ -89,6 +95,7 @@ class SmartCore::Initializer::Attribute::Value::Base
   # @since 0.8.0
   attr_reader :as
 
+  # @param klass [Class]
   # @param name [Symbol]
   # @param type [SmartCore::Initializer::TypeSystem::Interop]
   # @param type_system [Class<SmartCore::Initializer::TypeSystem::Interop>]
@@ -101,7 +108,8 @@ class SmartCore::Initializer::Attribute::Value::Base
   #
   # @api private
   # @since 0.8.0
-  def initialize(name, type, type_system, privacy, finalizer, cast, mutable, as)
+  def initialize(klass, name, type, type_system, privacy, finalizer, cast, mutable, as)
+    @klass = klass
     @name = name
     @type = type
     @type_system = type_system
@@ -121,10 +129,20 @@ class SmartCore::Initializer::Attribute::Value::Base
   # @since 0.8.0
   # @version 0.11.0
   def validate!(value)
-    raise(
-      SmartCore::Initializer::IncorrectTypeError,
-      "Validation of attribute `#{name}` failed:" \
-      "(expected: #{type.identifier}, got: #{value.class})"
-    ) unless type.valid?(value)
+    unless type.valid?(value)
+      raise(
+        SmartCore::Initializer::IncorrectTypeError,
+        "Validation of attribute `#{klass}##{name}` failed. " \
+        "Expected: #{type.identifier}, got: #{truncate(value.inspect, 100)}",
+      )
+    end
+  end
+
+  private
+
+  def truncate(string, length)
+    return string unless string.size > length
+    omission = "..."
+    "#{string[0, string.size - omission.size]}#{omission}"
   end
 end

--- a/lib/smart_core/initializer/attribute/value/base.rb
+++ b/lib/smart_core/initializer/attribute/value/base.rb
@@ -140,9 +140,9 @@ class SmartCore::Initializer::Attribute::Value::Base
 
   private
 
-  def truncate(string, length)
-    return string unless string.size > length
+  def truncate(string, max_length)
+    return string unless string.size > max_length
     omission = "..."
-    "#{string[0, string.size - omission.size]}#{omission}"
+    "#{string[0, max_length - omission.size]}#{omission}"
   end
 end

--- a/lib/smart_core/initializer/attribute/value/option.rb
+++ b/lib/smart_core/initializer/attribute/value/option.rb
@@ -23,6 +23,7 @@ module SmartCore::Initializer::Attribute::Value
     attr_reader :optional
     alias_method :optional?, :optional
 
+    # @param klass [Class]
     # @param name [Symbol]
     # @param type [SmartCore::Initializer::TypeSystem::Interop]
     # @param type_system [Class<SmartCore::Initializer::TypeSystem::Interop>]
@@ -38,6 +39,7 @@ module SmartCore::Initializer::Attribute::Value
     # @api private
     # @since 0.8.0
     def initialize(
+      klass,
       name,
       type,
       type_system,
@@ -49,7 +51,7 @@ module SmartCore::Initializer::Attribute::Value
       default,
       optional
     )
-      super(name, type, type_system, privacy, finalizer, cast, mutable, as)
+      super(klass, name, type, type_system, privacy, finalizer, cast, mutable, as)
       @default = default
       @optional = optional
     end
@@ -85,6 +87,7 @@ module SmartCore::Initializer::Attribute::Value
       default = @default.equal?(UNDEFINED_DEFAULT) ? @default : @default.dup
 
       self.class.new(
+        klass,
         name.dup,
         type,
         type_system,

--- a/lib/smart_core/initializer/attribute/value/param.rb
+++ b/lib/smart_core/initializer/attribute/value/param.rb
@@ -10,6 +10,7 @@ module SmartCore::Initializer::Attribute::Value
     # @since 0.8.0
     def dup
       self.class.new(
+        klass,
         name.dup,
         type,
         type_system,

--- a/lib/smart_core/initializer/constructor/definer.rb
+++ b/lib/smart_core/initializer/constructor/definer.rb
@@ -204,7 +204,7 @@ class SmartCore::Initializer::Constructor::Definer
     as
   )
     SmartCore::Initializer::Attribute::Factory::Param.create(
-      name, type, type_system, privacy, finalize, cast, mutable, as
+      klass, name, type, type_system, privacy, finalize, cast, mutable, as
     )
   end
 
@@ -236,7 +236,7 @@ class SmartCore::Initializer::Constructor::Definer
     optional
   )
     SmartCore::Initializer::Attribute::Factory::Option.create(
-      name, type, type_system, privacy, finalize, cast, mutable, as, default, optional
+      klass, name, type, type_system, privacy, finalize, cast, mutable, as, default, optional
     )
   end
 

--- a/lib/smart_core/initializer/version.rb
+++ b/lib/smart_core/initializer/version.rb
@@ -7,6 +7,6 @@ module SmartCore
     # @api public
     # @since 0.1.0
     # @version 0.11.1
-    VERSION = '0.11.1'
+    VERSION = '0.12.0'
   end
 end

--- a/smart_initializer.gemspec
+++ b/smart_initializer.gemspec
@@ -40,4 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'armitage-rubocop', '~> 1.30'
   spec.add_development_dependency 'simplecov',        '~> 0.21'
   spec.add_development_dependency 'pry',              '~> 0.14'
+  spec.add_development_dependency 'ostruct'
+  spec.add_development_dependency 'bigdecimal'
 end


### PR DESCRIPTION
Before;

```
[1] pry(main)> Values::PaymentFlow.new("jopa")
SmartCore::Initializer::IncorrectTypeError: Validation of attribute `flow` failed:(expected: Enum, got: String)
```

After:

```
[1] pry(main)> Values::PaymentFlow.new("jopa")
SmartCore::Initializer::IncorrectTypeError: Validation of attribute `Values::PaymentFlow#flow` failed. Expected: Enum, got: "jopa"
```